### PR TITLE
Error handling

### DIFF
--- a/src/Vivait/BootstrapBundle/Resources/public/js/vendor/jquery.dialog2.js
+++ b/src/Vivait/BootstrapBundle/Resources/public/js/vendor/jquery.dialog2.js
@@ -799,6 +799,32 @@
                     // If not, just inject the full result
                     responseText );
 
+            })
+            .fail(function( result ) {
+                var title = $('.modal-header h4');
+
+                if (title != null) {
+                    title[0].innerText = "Error " + result.status;
+                }
+
+                self.html(
+                    jQuery("<div>")
+                        .append(
+                            "<h4>" + result.statusText + "</h4>"
+                        )
+                        .append(
+                            "If you feel that this message is in error, please contact us so that we can " +
+                            "verify you have the correct permissions."
+                        )
+                );
+
+                self.dialog2("addButton", "Close", {
+                    click: function() {
+                        self.dialog2("close");
+                    },
+                    primary: false,
+                    type: "warning"
+                });
             });
 
         return this;


### PR DESCRIPTION
Adds error handling for failed AJAX requests, so that they don't just stay blank forever or display 'One moment please...' indefinitely.
This will add a title of "Error `statusCode`", with a user-friendly message below it. A close button will also be added at the bottom.